### PR TITLE
Reconnect ping socket on failure

### DIFF
--- a/src/ping.cpp
+++ b/src/ping.cpp
@@ -28,12 +28,18 @@ using namespace std::chrono;
 
 namespace ping {
 
+    // forward declarations
+    struct Target;
+    std::string resolve_hostname(const std::string& hostname);
+
     typedef std::chrono::high_resolution_clock mainclock;
     typedef std::chrono::time_point<mainclock> timestamp;
 
     std::atomic<bool> running;
     std::thread send_thread;
     std::thread recv_thread;
+
+    std::map<in_addr_t, std::unique_ptr<Target>> targets;
 
     struct ICMPPacket {
         struct icmphdr header;
@@ -79,6 +85,32 @@ namespace ping {
         };
     };
 
+    struct Target {
+        std::string host;
+        std::mutex mutex;
+        uint16_t sequence_number;
+        int16_t last_ping;
+        timestamp last_sent;
+        struct sockaddr_in addr;
+
+        Target(const std::string& host_) : host(host_), last_ping(-1), sequence_number(0)
+        {
+            auto resolved = resolve_hostname(host);
+            if (resolved.empty())
+                throw std::runtime_error(fmt::format("Can't resolve hostname '{}'", host));
+
+            memset(&addr, 0, sizeof(addr));
+            addr.sin_family = AF_INET;
+            inet_pton(AF_INET, resolved.c_str(), &addr.sin_addr);
+        }
+
+        std::string dump_json()
+        {
+            return fmt::format("{}", last_ping);
+        }
+    };
+
+    // helper functions
 
     std::string resolve_hostname(const std::string& hostname) {
 
@@ -117,31 +149,7 @@ namespace ping {
         return ~sum;
     }
 
-
-    struct Target {
-        std::string host;
-        std::mutex mutex;
-        uint16_t sequence_number;
-        int16_t last_ping;
-        timestamp last_sent;
-        struct sockaddr_in addr;
-
-        Target(const std::string& host_) : host(host_), last_ping(-1), sequence_number(0)
-        {
-            auto resolved = resolve_hostname(host);
-            if (resolved.empty())
-                throw std::runtime_error(fmt::format("Can't resolve hostname '{}'", host));
-
-            memset(&addr, 0, sizeof(addr));
-            addr.sin_family = AF_INET;
-            inet_pton(AF_INET, resolved.c_str(), &addr.sin_addr);
-        }
-
-        std::string dump_json()
-        {
-            return fmt::format("{}", last_ping);
-        }
-    };
+    // ping sending functions
 
     void send_ping(int sock_fd, struct ICMPPacket& packet, struct sockaddr_in& dest_addr) {
 
@@ -162,8 +170,6 @@ namespace ping {
         else if (len < sizeof(packet))
             std::cerr << "unable to send ping payload (buffer too big)" << std::endl;
     }
-
-    std::map<in_addr_t, std::unique_ptr<Target>> targets;
 
     void send_worker(milliseconds frequency) {
 
@@ -211,9 +217,9 @@ namespace ping {
         } while (running.load());
     }
 
+    // ping receiver functions
 
-    std::optional<std::tuple<in_addr_t, int16_t, timestamp>> ping_receive(int sock_fd)
-    {
+    std::optional<std::tuple<in_addr_t, int16_t, timestamp>> ping_receive(int sock_fd) {
         char recv_buffer[1500];
         struct sockaddr_in recv_addr;
         socklen_t addr_len = sizeof(recv_addr);
@@ -264,7 +270,6 @@ namespace ping {
         }
     }
 
-
     void receive_worker(milliseconds timeout){
 
         sock_wrap socket(timeout);
@@ -299,6 +304,8 @@ namespace ping {
 
         }
     }
+
+    // external interface facilities
 
     const std::string ping_stats_dump_json(){
 

--- a/src/ping.cpp
+++ b/src/ping.cpp
@@ -41,9 +41,20 @@ namespace ping {
     };
 
     struct sock_wrap {
-        int sock_fd;
+        int sock_fd = -1;
+        milliseconds timeout;
 
-        sock_wrap(milliseconds timeout) {
+        sock_wrap(milliseconds timeout_) : timeout(timeout_) {
+            reconnect();
+        }
+
+        ~sock_wrap() { close(sock_fd); }
+
+        void reconnect() {
+
+            if(sock_fd >= 0)
+                close(sock_fd);
+
             sock_fd = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
             if (sock_fd < 0) {
                 throw std::runtime_error(fmt::format("failed to create socket ({}: {}).",
@@ -58,7 +69,14 @@ namespace ping {
             setsockopt(sock_fd, SOL_SOCKET, SO_RCVTIMEO, &timeout_, sizeof(timeout_));
         }
 
-        ~sock_wrap() { close(sock_fd); }
+        struct failed_connection : std::exception {
+            std::string msg;
+            failed_connection() {
+                msg = fmt::format("recvfrom failed ({} {})", errno, std::strerror(errno));
+            }
+
+            const char* what() const noexcept override { return msg.c_str(); };
+        };
     };
 
 

--- a/src/ping.cpp
+++ b/src/ping.cpp
@@ -270,26 +270,33 @@ namespace ping {
         sock_wrap socket(timeout);
         while(running.load())
         {
-            auto res = ping_receive(socket.sock_fd);
+            try {
+                auto res = ping_receive(socket.sock_fd);
 
-            if(res)
-            {
-                auto [addr, sequence, received] = *res;
-
-                if( targets.contains(addr) )
+                if(res)
                 {
-                    auto& target = targets[addr];
-                    const std::lock_guard<std::mutex> lock(target->mutex);
+                    auto [addr, sequence, received] = *res;
 
-                    if(target->sequence_number == sequence){
-                        target->last_ping = duration_cast<milliseconds>(received - target->last_sent).count();
-                        //std::cout << "received echo reply for " << target->host
-                        //<< " " << sequence << std::endl;
+                    if( targets.contains(addr) )
+                    {
+                        auto& target = targets[addr];
+                        const std::lock_guard<std::mutex> lock(target->mutex);
+
+                        if(target->sequence_number == sequence){
+                            target->last_ping = duration_cast<milliseconds>(received - target->last_sent).count();
+                        }
                     }
                 }
-            }
-            else
+                else
+                    std::this_thread::sleep_for(milliseconds(10)); // rate limit failures
+
+            } catch (sock_wrap::failed_connection& e) {
+                std::cerr << e.what() << std::endl;
+                std::cerr << "reconnecting receive socket" << std::endl;
+                socket.reconnect();
                 std::this_thread::sleep_for(milliseconds(1000));
+            }
+
         }
     }
 

--- a/src/ping.cpp
+++ b/src/ping.cpp
@@ -186,18 +186,28 @@ namespace ping {
 
         do
         {
-            for (const auto& [k, v] : targets )// | std::views::values ) {
-            {
+            try {
+
+                for (const auto& [k, v] : targets )// | std::views::values ) {
                 {
-                    const std::lock_guard<std::mutex> lock(v->mutex);
-                    packet.header.un.echo.sequence = ++(v->sequence_number);
-                    packet.header.checksum = 0; // reset to 0 to not poison our own checksum!
-                    packet.header.checksum = calculate_checksum(&packet, sizeof(packet));
-                    v->last_sent = mainclock::now();
+                    {
+                        const std::lock_guard<std::mutex> lock(v->mutex);
+                        packet.header.un.echo.sequence = ++(v->sequence_number);
+                        packet.header.checksum = 0; // reset to 0 to not poison our own checksum!
+                        packet.header.checksum = calculate_checksum(&packet, sizeof(packet));
+                        v->last_sent = mainclock::now();
+                    }
+                    send_ping(socket.sock_fd, packet, v->addr);
                 }
-                send_ping(socket.sock_fd, packet, v->addr);
+
+                std::this_thread::sleep_for(frequency);
+
+            } catch (sock_wrap::failed_connection) {
+
+                std::cerr << "reconnecting send socket" << std::endl;
+                socket.reconnect();
+                std::this_thread::sleep_for(milliseconds(1000));
             }
-            std::this_thread::sleep_for(frequency);
         } while (running.load());
     }
 

--- a/src/ping.cpp
+++ b/src/ping.cpp
@@ -152,9 +152,13 @@ namespace ping {
                              (struct sockaddr*)&dest_addr,
                              sizeof(dest_addr));
 
-        if (len < 0)
+        if (len == -1)
+            throw sock_wrap::failed_connection();
+        else if (len < 0)
+        {
             std::cerr << "unable to send ping payload (err " << errno
                       << " - " << std::strerror(errno) << ")" << std::endl;
+        }
         else if (len < sizeof(packet))
             std::cerr << "unable to send ping payload (buffer too big)" << std::endl;
     }
@@ -211,7 +215,10 @@ namespace ping {
                                (struct sockaddr*)&recv_addr,
                                &addr_len);
 
-        if (len < 0) {
+        if (len == -1)
+            throw sock_wrap::failed_connection();
+        else if (len < 0)
+        {
             std::cerr << "recvfrom failed (" << errno << " " << std::strerror(errno) << ")" << std::endl;
             return std::nullopt;
         }

--- a/src/ping.cpp
+++ b/src/ping.cpp
@@ -329,7 +329,7 @@ namespace ping {
             }
         }
 
-        recv_thread = std::move(std::thread(receive_worker, milliseconds(frequency)));
+        recv_thread = std::move(std::thread(receive_worker, milliseconds(frequency * 3)));
         send_thread = std::move(std::thread(send_worker, milliseconds(frequency)));
     }
 


### PR DESCRIPTION
feature to make sure that if for some reason the underlying interfaces restart and the network sockets are invalidated, we don't simply remain in a forever failure loop. This update makes it so that if `sendto` or `recvfrom` returns -1, we consider it a failed socket and reconnect it.